### PR TITLE
AVPlayer & related APIs exposed outside Kaltura environment

### DIFF
--- a/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
@@ -420,7 +420,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
     public func adsRequestTimedOut(shouldPlay: Bool) {
         if stateMachine.getState() == .waitingForPrepare, adRequestTimedOutRetries < maxAdRequestTimedOutRetries {
             adRequestTimedOutRetries += 1
-            prepare(prepareMediaConfig, mediaAsset: nil)
+            prepare(prepareMediaConfig)
         } else {
             playOriginalMedia()
         }

--- a/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
@@ -157,7 +157,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         if stateMachine.getState() == .waitingForPrepare {
             stateMachine.set(state: .preparing)
             PKLog.debug("Will prepare player")
-            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
+            super.prepare(self.prepareMediaConfig)
             stateMachine.set(state: .prepared)
         }
         
@@ -168,7 +168,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         if stateMachine.getState() == .waitingForPrepare {
             preparePlayerIfNeeded()
             if let mediaSource = mediaSource, let handler = handler {
-                super.loadMedia(from: mediaSource, mediaAsset: nil, handler: handler)
+                super.loadMedia(from: mediaSource, handler: handler)
             }
             if playPerformed {
                 super.play()
@@ -215,8 +215,8 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
             playerEngine?.currentTime = streamTime
         }
     }
-    
-    public override func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
+
+    public override func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset? = nil, handler: AssetHandler) {
         reset()
         
         self.mediaSource = mediaSource
@@ -312,7 +312,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         super.destroy()
     }
     
-    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         prepareMediaConfig = config
         stateMachine.set(state: .waitingForPrepare)
         do {
@@ -349,7 +349,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
             source.contentUrl = streamURL
         }
         if let mediaSource = mediaSource, let handler = handler {
-            super.loadMedia(from: mediaSource, mediaAsset: nil, handler: handler)
+            super.loadMedia(from: mediaSource, handler: handler)
             
             preparePlayerIfNeeded()
         }
@@ -371,7 +371,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         // The loader can fail also when going to the background, therefore adding the retry here as well.
         if adRequestTimedOutRetries < maxAdRequestTimedOutRetries, prepareMediaConfig != nil {
             adRequestTimedOutRetries += 1
-            prepare(prepareMediaConfig, mediaAsset: nil)
+            prepare(prepareMediaConfig)
         } else {
             playOriginalMedia()
         }

--- a/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
@@ -157,7 +157,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         if stateMachine.getState() == .waitingForPrepare {
             stateMachine.set(state: .preparing)
             PKLog.debug("Will prepare player")
-            super.prepare(self.prepareMediaConfig)
+            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
             stateMachine.set(state: .prepared)
         }
         
@@ -168,7 +168,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         if stateMachine.getState() == .waitingForPrepare {
             preparePlayerIfNeeded()
             if let mediaSource = mediaSource, let handler = handler {
-                super.loadMedia(from: mediaSource, handler: handler)
+                super.loadMedia(from: mediaSource, mediaAsset: nil, handler: handler)
             }
             if playPerformed {
                 super.play()
@@ -216,7 +216,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         }
     }
     
-    public override func loadMedia(from mediaSource: PKMediaSource?, handler: AssetHandler) {
+    public override func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
         reset()
         
         self.mediaSource = mediaSource
@@ -312,7 +312,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         super.destroy()
     }
     
-    override public func prepare(_ config: MediaConfig) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
         prepareMediaConfig = config
         stateMachine.set(state: .waitingForPrepare)
         do {
@@ -349,7 +349,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
             source.contentUrl = streamURL
         }
         if let mediaSource = mediaSource, let handler = handler {
-            super.loadMedia(from: mediaSource, handler: handler)
+            super.loadMedia(from: mediaSource, mediaAsset: nil, handler: handler)
             
             preparePlayerIfNeeded()
         }
@@ -371,7 +371,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         // The loader can fail also when going to the background, therefore adding the retry here as well.
         if adRequestTimedOutRetries < maxAdRequestTimedOutRetries, prepareMediaConfig != nil {
             adRequestTimedOutRetries += 1
-            prepare(prepareMediaConfig)
+            prepare(prepareMediaConfig, mediaAsset: nil)
         } else {
             playOriginalMedia()
         }
@@ -420,7 +420,7 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
     public func adsRequestTimedOut(shouldPlay: Bool) {
         if stateMachine.getState() == .waitingForPrepare, adRequestTimedOutRetries < maxAdRequestTimedOutRetries {
             adRequestTimedOutRetries += 1
-            prepare(prepareMediaConfig)
+            prepare(prepareMediaConfig, mediaAsset: nil)
         } else {
             playOriginalMedia()
         }

--- a/Classes/Player/Ads/AdsEnabledPlayerController.swift
+++ b/Classes/Player/Ads/AdsEnabledPlayerController.swift
@@ -64,7 +64,7 @@ public class AdsEnabledPlayerController : PlayerDecoratorBase, AdsPluginDelegate
         }
     }
     
-    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         self.stateMachine.set(state: .start)
         self.adsPlugin.destroyManager()
         self.isPlayEnabled = false
@@ -191,7 +191,7 @@ public class AdsEnabledPlayerController : PlayerDecoratorBase, AdsPluginDelegate
         if self.stateMachine.getState() == .waitingForPrepare {
             self.stateMachine.set(state: .preparing)
             PKLog.debug("will prepare player")
-            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
+            super.prepare(self.prepareMediaConfig)
             self.stateMachine.set(state: .prepared)
         }
         

--- a/Classes/Player/Ads/AdsEnabledPlayerController.swift
+++ b/Classes/Player/Ads/AdsEnabledPlayerController.swift
@@ -64,7 +64,7 @@ public class AdsEnabledPlayerController : PlayerDecoratorBase, AdsPluginDelegate
         }
     }
     
-    override public func prepare(_ config: MediaConfig) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
         self.stateMachine.set(state: .start)
         self.adsPlugin.destroyManager()
         self.isPlayEnabled = false
@@ -191,7 +191,7 @@ public class AdsEnabledPlayerController : PlayerDecoratorBase, AdsPluginDelegate
         if self.stateMachine.getState() == .waitingForPrepare {
             self.stateMachine.set(state: .preparing)
             PKLog.debug("will prepare player")
-            super.prepare(self.prepareMediaConfig)
+            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
             self.stateMachine.set(state: .prepared)
         }
         

--- a/Classes/Player/Ads/AdsPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsPlayerEngineWrapper.swift
@@ -64,7 +64,7 @@ public class AdsPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, Ads
         if self.stateMachine.getState() == .waitingForPrepare {
             self.stateMachine.set(state: .preparing)
             PKLog.debug("will prepare player")
-            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
+            super.prepare(self.prepareMediaConfig)
             self.stateMachine.set(state: .prepared)
         }
         
@@ -80,7 +80,7 @@ public class AdsPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, Ads
         }
     }
     
-    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         self.stateMachine.set(state: .start)
         self.adsPlugin.destroyManager()
         self.isPlayEnabled = false

--- a/Classes/Player/Ads/AdsPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsPlayerEngineWrapper.swift
@@ -1,6 +1,7 @@
 
 
 import Foundation
+import AVFoundation
 
 /// `AdsPlayerEngineWrapperState` represents `AdsPlayerEngineWrapper` state machine states.
 enum AdsPlayerEngineWrapperState: Int, StateProtocol {
@@ -63,7 +64,7 @@ public class AdsPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, Ads
         if self.stateMachine.getState() == .waitingForPrepare {
             self.stateMachine.set(state: .preparing)
             PKLog.debug("will prepare player")
-            super.prepare(self.prepareMediaConfig)
+            super.prepare(self.prepareMediaConfig, mediaAsset: nil)
             self.stateMachine.set(state: .prepared)
         }
         
@@ -79,7 +80,7 @@ public class AdsPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, Ads
         }
     }
     
-    override public func prepare(_ config: MediaConfig) {
+    override public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
         self.stateMachine.set(state: .start)
         self.adsPlugin.destroyManager()
         self.isPlayEnabled = false

--- a/Classes/Player/Decorators/PlayerDecoratorBase.swift
+++ b/Classes/Player/Decorators/PlayerDecoratorBase.swift
@@ -201,7 +201,7 @@ import AVKit
         self.player.destroy()
     }
     
-    open func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    open func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         self.player.prepare(config, mediaAsset: mediaAsset)
     }
     

--- a/Classes/Player/Decorators/PlayerDecoratorBase.swift
+++ b/Classes/Player/Decorators/PlayerDecoratorBase.swift
@@ -116,6 +116,15 @@ import AVKit
             self.player.view = newValue
         }
     }
+
+    public var assetToPrepare: AVURLAsset? {
+        get {
+            return self.player.assetToPrepare
+        }
+        set {
+            self.player.assetToPrepare = newValue
+        }
+    }
     
     public var currentTime: TimeInterval {
         get {
@@ -192,8 +201,8 @@ import AVKit
         self.player.destroy()
     }
     
-    open func prepare(_ config: MediaConfig) {
-        self.player.prepare(config)
+    open func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+        self.player.prepare(config, mediaAsset: mediaAsset)
     }
     
     public func startBuffering() {

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -311,7 +311,7 @@ class PlayerController: NSObject, Player {
         self.removeAssetRefreshObservers()
     }
     
-    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
+    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         self.currentPlayer.prepare(mediaConfig, mediaAsset: mediaAsset)
         
         if let source = self.selectedSource {

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -9,6 +9,7 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 class PlayerController: NSObject, Player {
     
@@ -172,6 +173,11 @@ class PlayerController: NSObject, Player {
         get { return self.currentPlayer.view }
         set { self.currentPlayer.view = newValue }
     }
+
+    public var assetToPrepare: AVURLAsset? {
+        get { return self.currentPlayer.assetToPrepare }
+        set { self.currentPlayer.assetToPrepare = newValue }
+    }
     
     public var currentTime: TimeInterval {
         get {
@@ -305,8 +311,8 @@ class PlayerController: NSObject, Player {
         self.removeAssetRefreshObservers()
     }
     
-    func prepare(_ mediaConfig: MediaConfig) {
-        self.currentPlayer.prepare(mediaConfig)
+    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
+        self.currentPlayer.prepare(mediaConfig, mediaAsset: mediaAsset)
         
         if let source = self.selectedSource {
             self.mediaFormat = source.mediaFormat
@@ -372,7 +378,7 @@ class PlayerController: NSObject, Player {
     // MARK: - Public Functions
     // ****************************************** //
     
-    func setMedia(from mediaConfig: MediaConfig) {
+    func setMedia(from mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
         self.mediaConfig = mediaConfig
         
         // create new media session uuid
@@ -412,7 +418,7 @@ class PlayerController: NSObject, Player {
         // Reset the pause position
         liveDVRPausedPosition = nil
         
-        self.currentPlayer.loadMedia(from: self.selectedSource, handler: handler)
+        self.currentPlayer.loadMedia(from: self.selectedSource, mediaAsset: mediaAsset, handler: handler)
     }
 }
 

--- a/Classes/Player/PlayerEngineWrapper.swift
+++ b/Classes/Player/PlayerEngineWrapper.swift
@@ -120,7 +120,7 @@ public class PlayerEngineWrapper: NSObject, PlayerEngine {
         return playerEngine?.loadedTimeRanges
     }
     
-    public func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
+    public func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset? = nil, handler: AssetHandler) {
         playerEngine?.loadMedia(from: mediaSource, mediaAsset: mediaAsset, handler: handler)
     }
     
@@ -164,7 +164,7 @@ public class PlayerEngineWrapper: NSObject, PlayerEngine {
         playerEngine?.destroy()
     }
     
-    public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         playerEngine?.prepare(config, mediaAsset: mediaAsset)
     }
     

--- a/Classes/Player/PlayerEngineWrapper.swift
+++ b/Classes/Player/PlayerEngineWrapper.swift
@@ -1,6 +1,7 @@
 
 
 import Foundation
+import AVFoundation
 
 public class PlayerEngineWrapper: NSObject, PlayerEngine {
     
@@ -66,6 +67,15 @@ public class PlayerEngineWrapper: NSObject, PlayerEngine {
             playerEngine?.view = newValue
         }
     }
+
+    public var assetToPrepare: AVURLAsset? {
+        get {
+            return playerEngine?.assetToPrepare
+        }
+        set {
+            playerEngine?.assetToPrepare = newValue
+        }
+    }
     
     public var currentTime: TimeInterval {
         get {
@@ -110,8 +120,8 @@ public class PlayerEngineWrapper: NSObject, PlayerEngine {
         return playerEngine?.loadedTimeRanges
     }
     
-    public func loadMedia(from mediaSource: PKMediaSource?, handler: AssetHandler) {
-        playerEngine?.loadMedia(from: mediaSource, handler: handler)
+    public func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
+        playerEngine?.loadMedia(from: mediaSource, mediaAsset: mediaAsset, handler: handler)
     }
     
     public func playFromLiveEdge() {
@@ -154,8 +164,8 @@ public class PlayerEngineWrapper: NSObject, PlayerEngine {
         playerEngine?.destroy()
     }
     
-    public func prepare(_ config: MediaConfig) {
-        playerEngine?.prepare(config)
+    public func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+        playerEngine?.prepare(config, mediaAsset: mediaAsset)
     }
     
     public func startBuffering() {

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -73,7 +73,7 @@ class PlayerLoader: PlayerDecoratorBase {
         setPlayer(player)
     }
     
-    override func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+    override func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         self.concreatePlayerController?.setMedia(from: config, mediaAsset: mediaAsset)
         super.prepare(config, mediaAsset: mediaAsset)
         // update all loaded plugins with media config

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -9,6 +9,7 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 class LoadedPlugin: NSObject {
     var plugin: PKPlugin
@@ -72,9 +73,9 @@ class PlayerLoader: PlayerDecoratorBase {
         setPlayer(player)
     }
     
-    override func prepare(_ config: MediaConfig) {
-        self.concreatePlayerController?.setMedia(from: config)
-        super.prepare(config)
+    override func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?) {
+        self.concreatePlayerController?.setMedia(from: config, mediaAsset: mediaAsset)
+        super.prepare(config, mediaAsset: mediaAsset)
         // update all loaded plugins with media config
         for (pluginName, loadedPlugin) in loadedPlugins {
             PKLog.verbose("Preparing plugin \(pluginName)")

--- a/Classes/Player/PlayerView.swift
+++ b/Classes/Player/PlayerView.swift
@@ -14,7 +14,7 @@ import AVFoundation
 /// A simple `UIView` subclass that is backed by an `AVPlayerLayer` layer.
 @objc public class PlayerView: UIView {
     
-    var player: AVPlayer? {
+    @objc public var player: AVPlayer? {
         get {
             return playerLayer.player
         }

--- a/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
+++ b/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
@@ -103,7 +103,7 @@ open class AVPlayerWrapper: NSObject, PlayerEngine {
         return self.currentPlayer.playbackType
     }
     
-    open func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
+    open func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset? = nil, handler: AssetHandler) {
         if mediaAsset != nil {
             self.assetToPrepare = mediaAsset
             self.prepareSemaphore.signal()
@@ -236,7 +236,7 @@ open class AVPlayerWrapper: NSObject, PlayerEngine {
         self.removeAssetRefreshObservers()
     }
     
-    public func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
+    public func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         // set background thread to make sure main thread is not stuck while waiting
         DispatchQueue.global().async {
             // wait till assetToPrepare is set

--- a/Classes/Player/PlayerWrapper/DefaultPlayerWrapper.swift
+++ b/Classes/Player/PlayerWrapper/DefaultPlayerWrapper.swift
@@ -46,7 +46,7 @@ class DefaultPlayerWrapper: NSObject, PlayerEngine {
         return nil
     }
     
-    func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
+    func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset? = nil, handler: AssetHandler) {
         printInvocationWarning("\(#function)")
     }
     
@@ -170,7 +170,7 @@ class DefaultPlayerWrapper: NSObject, PlayerEngine {
         printInvocationWarning("\(#function)")
     }
     
-    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
+    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset? = nil) {
         printInvocationWarning("\(#function)")
     }
     

--- a/Classes/Player/PlayerWrapper/DefaultPlayerWrapper.swift
+++ b/Classes/Player/PlayerWrapper/DefaultPlayerWrapper.swift
@@ -9,6 +9,7 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 class DefaultPlayerWrapper: NSObject, PlayerEngine {
     
@@ -45,7 +46,7 @@ class DefaultPlayerWrapper: NSObject, PlayerEngine {
         return nil
     }
     
-    func loadMedia(from mediaSource: PKMediaSource?, handler: AssetHandler) {
+    func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler) {
         printInvocationWarning("\(#function)")
     }
     
@@ -78,6 +79,14 @@ class DefaultPlayerWrapper: NSObject, PlayerEngine {
     
     /// Save view reference till prepare
     public weak var view: PlayerView?
+
+    public var assetToPrepare: AVURLAsset? {
+        get {
+            printInvocationWarning("\(#function)")
+            return nil
+        }
+        set { printInvocationWarning("\(#function)") }
+    }
     
     public var currentTime: TimeInterval {
         get {
@@ -161,7 +170,7 @@ class DefaultPlayerWrapper: NSObject, PlayerEngine {
         printInvocationWarning("\(#function)")
     }
     
-    func prepare(_ mediaConfig: MediaConfig) {
+    func prepare(_ mediaConfig: MediaConfig, mediaAsset: AVURLAsset?) {
         printInvocationWarning("\(#function)")
     }
     

--- a/Classes/Player/Protocols/BasicPlayer.swift
+++ b/Classes/Player/Protocols/BasicPlayer.swift
@@ -9,8 +9,12 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 @objc public protocol BasicPlayer {
+    /// The player item's asset.
+    @objc var assetToPrepare: AVURLAsset? { get set }
+
     /// The player's duration.
     @objc var duration: TimeInterval { get }
     
@@ -72,7 +76,7 @@ import Foundation
     /// Prepare for playing an entry.
     /// If player network setting autoBuffer is set to true, prepare starts buffering the entry.
     /// Otherwise, if autoBuffer is set to false, need to call startBuffering manually.
-    @objc func prepare(_ config: MediaConfig)
+    @objc func prepare(_ config: MediaConfig, mediaAsset: AVURLAsset?)
     
     /// Starts buffering the entry.
     @objc func startBuffering()

--- a/Classes/Player/Protocols/PlayerEngine.swift
+++ b/Classes/Player/Protocols/PlayerEngine.swift
@@ -9,6 +9,7 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 @objc public protocol PlayerEngine: BasicPlayer {
     /// Fired when an event is triggred.
@@ -27,7 +28,7 @@ import Foundation
     var playbackType: String? { get }
     
     /// Load the media to the player.
-    func loadMedia(from mediaSource: PKMediaSource?, handler: AssetHandler)
+    func loadMedia(from mediaSource: PKMediaSource?, mediaAsset: AVURLAsset?, handler: AssetHandler)
     
     /// Plays the live media from the live edge.
     func playFromLiveEdge()


### PR DESCRIPTION
### Description of the Changes

Kaltura Player just exposes its own wrapper to set source & various other props. This limits developer to leverage APIs related to core AVPlayer, which leads to having no control over the underlying player.

This PR exposes AVPlayer & AVURLAsset, which can be assigned through configurations. Previously generated Assets can also be used here if data needs to be picked from the downloaded resource.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
